### PR TITLE
Bugfix: HTTP method to send traces is PUT in specs

### DIFF
--- a/src/main/scala/kamon/datadog/DatadogSpanReporter.scala
+++ b/src/main/scala/kamon/datadog/DatadogSpanReporter.scala
@@ -70,7 +70,7 @@ class DatadogSpanReporter extends SpanReporter {
       .groupBy { _.\("trace_id").get.toString() }
       .values
       .toList
-    httpClient.doJsonPost(Json.toJson(spanList))
+    httpClient.doJsonPut(Json.toJson(spanList))
   }
 
   override def start(): Unit = {

--- a/src/test/scala/kamon/datadog/DatadogAPIReporterSpec.scala
+++ b/src/test/scala/kamon/datadog/DatadogAPIReporterSpec.scala
@@ -39,6 +39,7 @@ class DatadogAPIReporterSpec extends AbstractHttpReporter with Matchers with Rec
       )
       val request = server.takeRequest()
       request.getRequestUrl.toString shouldEqual baseUrl + "?api_key=dummy"
+      request.getMethod shouldEqual "POST"
       Json.parse(request.getBody().readUtf8()) shouldEqual Json.parse("""{"series":[{"metric":"test.counter","interval":1,"points":[[1523394,0]],"type":"count","host":"test","tags":["service:kamon-application","env:staging","tag1:value1"]}]}""")
 
     }

--- a/src/test/scala/kamon/datadog/DatadogSpanReporterSpec.scala
+++ b/src/test/scala/kamon/datadog/DatadogSpanReporterSpec.scala
@@ -148,6 +148,7 @@ class DatadogSpanReporterSpec extends AbstractHttpReporter with Matchers with Re
         reporter.reportSpans(spans)
         val request = server.takeRequest()
         val url = request.getRequestUrl().toString()
+        val method = request.getMethod()
         val requestJson = Json.parse(request.getBody().readUtf8()).as[JsArray]
 
         // Ordering stuff
@@ -156,6 +157,7 @@ class DatadogSpanReporterSpec extends AbstractHttpReporter with Matchers with Re
 
         url shouldEqual baseUrl
         sortedRequestJson shouldEqual sortedTestData
+        method shouldEqual "PUT"
 
       }
     }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.0-C1.0.1"
+version in ThisBuild := "1.0.0-C1.0.2"


### PR DESCRIPTION
It was already working with POST, but conforming to [specs](https://docs.datadoghq.com/api/?lang=python#tracing), it must be PUT